### PR TITLE
Upgrade project to JDK 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 21
+          java-version: 24
       - name: build
         run: ./gradlew clean build --no-daemon --refresh-dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,23 @@ sourceSets {
   }
 }
 
+tasks.withType(GroovyCompile).configureEach { compileTask ->
+    if (compileTask.name.equals('compileTestGroovy')) {
+        def testGroovyClasspathConfig = project.configurations.detachedConfiguration(
+            project.dependencies.create('org.apache.groovy:groovy:4.0.21'),
+            project.dependencies.create('org.apache.groovy:groovy-test:4.0.21')
+        )
+
+        compileTask.groovyClasspath = testGroovyClasspathConfig
+        if (compileTask.options.hasProperty('groovyOptions') && compileTask.options.groovyOptions.hasProperty('targetBytecodeVersion')) {
+            compileTask.options.groovyOptions.targetBytecodeVersion = JavaLanguageVersion.of(24).toString()
+        } else {
+             compileTask.options.forkOptions.jvmArgs += ['-Dgroovy.target.bytecode=24']
+        }
+
+    }
+}
+
 gradle.projectsEvaluated {
   tasks.withType(JavaCompile).tap {
     configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,12 @@ tasks.withType(AbstractCompile)*.options*.encoding = tasks.withType(GroovyCompil
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(24)
     }
 }
 
-sourceCompatibility = '21'
-targetCompatibility = '21'
+sourceCompatibility = '24'
+targetCompatibility = '24'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation group: 'org.ow2.asm', name: 'asm-util', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-tree', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-analysis', version: asmVersion
-    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.4-M4-groovy-4.0'
+    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.3-groovy-4.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
@@ -43,6 +43,7 @@ test {
     testLogging {
         events 'passed', 'failed', 'skipped'
     }
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
 }
 
 gradle.projectsEvaluated {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation group: 'org.ow2.asm', name: 'asm-analysis', version: asmVersion
     testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.3-groovy-4.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation 'org.apache.groovy:groovy:4.0.21'
+    testImplementation 'org.apache.groovy:groovy-test:4.0.21'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ dependencies {
     implementation group: 'org.ow2.asm', name: 'asm-util', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-tree', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-analysis', version: asmVersion
-    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.3-groovy-4.0'
+    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.4-M6-groovy-4.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation 'org.apache.groovy:groovy:4.0.21'
-    testImplementation 'org.apache.groovy:groovy-test:4.0.21'
+    testImplementation 'org.apache.groovy:groovy:4.0.27'
+    testImplementation 'org.apache.groovy:groovy-test:4.0.27'
 }
 
 test {
@@ -97,23 +97,6 @@ sourceSets {
       exclude("**/*_ja.properties")
     }
   }
-}
-
-tasks.withType(GroovyCompile).configureEach { compileTask ->
-    if (compileTask.name.equals('compileTestGroovy')) {
-        def testGroovyClasspathConfig = project.configurations.detachedConfiguration(
-            project.dependencies.create('org.apache.groovy:groovy:4.0.21'),
-            project.dependencies.create('org.apache.groovy:groovy-test:4.0.21')
-        )
-
-        compileTask.groovyClasspath = testGroovyClasspathConfig
-        if (compileTask.options.hasProperty('groovyOptions') && compileTask.options.groovyOptions.hasProperty('targetBytecodeVersion')) {
-            compileTask.options.groovyOptions.targetBytecodeVersion = JavaLanguageVersion.of(24).toString()
-        } else {
-             compileTask.options.forkOptions.jvmArgs += ['-Dgroovy.target.bytecode=24']
-        }
-
-    }
 }
 
 gradle.projectsEvaluated {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This commit updates your project configuration to use JDK 24.

Changes include:
- Modified `build.gradle` to set Java toolchain version, sourceCompatibility, and targetCompatibility to 24.
- Updated `.github/workflows/build.yml` to use `java-version: 24`.

Due to limitations in my development environment, I couldn't perform a full compilation and test with JDK 24 directly. The CI build will be the primary validation for JDK 24 compatibility. Further fixes may be required based on CI results.