### PR TITLE
Feat: Upgrade to JDK 24 and update related dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 21
+          java-version: 24
       - name: build
         run: ./gradlew clean build --no-daemon --refresh-dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,12 @@ tasks.withType(AbstractCompile)*.options*.encoding = tasks.withType(GroovyCompil
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(24)
     }
 }
 
-sourceCompatibility = '21'
-targetCompatibility = '21'
+sourceCompatibility = '24'
+targetCompatibility = '24'
 
 repositories {
     mavenCentral()
@@ -35,14 +35,17 @@ dependencies {
     implementation group: 'org.ow2.asm', name: 'asm-util', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-tree', version: asmVersion
     implementation group: 'org.ow2.asm', name: 'asm-analysis', version: asmVersion
-    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.4-M4-groovy-4.0'
+    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.4-M6-groovy-4.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation 'org.apache.groovy:groovy:4.0.27'
+    testImplementation 'org.apache.groovy:groovy-test:4.0.27'
 }
 
 test {
     testLogging {
         events 'passed', 'failed', 'skipped'
     }
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
 }
 
 gradle.projectsEvaluated {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This single commit consolidates all changes for the JDK 24 upgrade:

Build Configuration (`build.gradle`):
- Sets Java toolchain to version 24.
- Sets sourceCompatibility and targetCompatibility to '24'.
- Updates Spock to `org.spockframework:spock-core:2.4-M6-groovy-4.0`.
- Sets explicit Groovy dependencies to `org.apache.groovy:groovy:4.0.27` and `org.apache.groovy:groovy-test:4.0.27` to leverage ASM 9.8 for JDK 24 bytecode compatibility.
- Adds `jvmArgs '--enable-native-access=ALL-UNNAMED'` to the test task to address native access warnings.

Gradle Wrapper (`gradle/wrapper/gradle-wrapper.properties`):
- Updates `distributionUrl` to Gradle version 8.14.2.

CI Workflow (`.github/workflows/build.yml`):
- Sets `java-version` to 24 for the build environment.

These changes are intended to enable building and testing your project with JDK 24 and resolve previous test compilation issues.